### PR TITLE
fix: configure CI/CD triggers to match DevFlow strategy

### DIFF
--- a/.github/workflows/cd.yml
+++ b/.github/workflows/cd.yml
@@ -4,7 +4,7 @@ on:
   push:
     branches: [ main ]  # Production部署
   pull_request:
-    branches: [ main ]  # Staging部署
+    branches: [ main, dev ]  # PR to main = Production, PR to dev = Staging
   workflow_dispatch:   # 手動觸發
     inputs:
       environment:
@@ -58,7 +58,10 @@ jobs:
           # main分支推送 -> Production
           TARGET_ENV="production"
         elif [ "${{ github.base_ref }}" = "main" ] && [ "${{ github.event_name }}" = "pull_request" ]; then
-          # PR到main -> Staging  
+          # PR到main -> Production  
+          TARGET_ENV="production"
+        elif [ "${{ github.base_ref }}" = "dev" ] && [ "${{ github.event_name }}" = "pull_request" ]; then
+          # PR到dev -> Staging
           TARGET_ENV="staging"
         else
           # 其他情況不部署

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -2,9 +2,9 @@ name: 🚀 Continuous Integration
 
 on:
   push:
-    branches: [ main, develop, feature/* ]
+    branches: [ main, dev, feature/* ]
   pull_request:
-    branches: [ main, develop ]
+    branches: [ main, dev ]
   workflow_dispatch:  # 手動觸發
 
 env:

--- a/setup-gcp-oidc.sh
+++ b/setup-gcp-oidc.sh
@@ -12,7 +12,7 @@ set -e  # 遇到錯誤立即退出
 
 # 配置變數
 PROJECT_ID="ton-cat-lottery-dev-3"
-GITHUB_REPO="chaowei-liu/ton-cat-lottery"
+GITHUB_REPO="chaowei-dev/ton-cat-lottery"
 SERVICE_ACCOUNT_NAME="gha-deploy"
 WORKLOAD_IDENTITY_POOL_NAME="github-pool" 
 WORKLOAD_IDENTITY_PROVIDER_NAME="github-provider"


### PR DESCRIPTION
## 🔧 修正 CI/CD 觸發邏輯

根據 DevFlow.png 開發流程，調整 CI/CD 工作流程觸發條件：

### ✅ **修正內容**
- **CI**: 支援 push/PR 到  分支觸發
- **CD**: PR 到  → Staging 部署，PR 到  → Production 部署

### 🧪 **測試 Staging 部署**
此 PR 應該會觸發：
1. CI 品質檢查 ✓
2. CD Staging 部署 → dev.cat-lottery.chaowei-liu.com

這樣就符合 DevFlow.png 的開發策略了！