### PR TITLE
fix: OIDC authentication with principalSet binding - final test

### DIFF
--- a/.github/workflows/cd.yml
+++ b/.github/workflows/cd.yml
@@ -233,6 +233,11 @@ jobs:
     - name: 🔧 Set up Cloud SDK
       uses: google-github-actions/setup-gcloud@v2
       
+    - name: 🔌 Install GKE gcloud auth plugin
+      run: |
+        gcloud components install gke-gcloud-auth-plugin --quiet
+        echo "✅ GKE auth plugin installed"
+      
     - name: ⚙️ Configure kubectl
       run: |
         gcloud container clusters get-credentials ${{ env.CLUSTER_NAME }} \
@@ -379,6 +384,14 @@ jobs:
       with:
         workload_identity_provider: ${{ secrets.GCP_WIF_PROVIDER }}
         service_account: ${{ secrets.GCP_SERVICE_ACCOUNT }}
+        
+    - name: 🔧 Set up Cloud SDK
+      uses: google-github-actions/setup-gcloud@v2
+      
+    - name: 🔌 Install GKE gcloud auth plugin  
+      run: |
+        gcloud components install gke-gcloud-auth-plugin --quiet
+        echo "✅ GKE auth plugin installed"
         
     - name: ⚙️ Configure kubectl
       run: |

--- a/.github/workflows/cd.yml
+++ b/.github/workflows/cd.yml
@@ -4,7 +4,7 @@ on:
   push:
     branches: [ main ]  # Production部署
   pull_request:
-    branches: [ main ]  # Staging部署
+    branches: [ main, dev ]  # PR to main = Production, PR to dev = Staging
   workflow_dispatch:   # 手動觸發
     inputs:
       environment:
@@ -58,7 +58,10 @@ jobs:
           # main分支推送 -> Production
           TARGET_ENV="production"
         elif [ "${{ github.base_ref }}" = "main" ] && [ "${{ github.event_name }}" = "pull_request" ]; then
-          # PR到main -> Staging  
+          # PR到main -> Production  
+          TARGET_ENV="production"
+        elif [ "${{ github.base_ref }}" = "dev" ] && [ "${{ github.event_name }}" = "pull_request" ]; then
+          # PR到dev -> Staging
           TARGET_ENV="staging"
         else
           # 其他情況不部署

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -2,9 +2,9 @@ name: 🚀 Continuous Integration
 
 on:
   push:
-    branches: [ main, develop, feature/* ]
+    branches: [ main, dev, feature/* ]
   pull_request:
-    branches: [ main, develop ]
+    branches: [ main, dev ]
   workflow_dispatch:  # 手動觸發
 
 env:

--- a/docs/DevOpsREADME.md
+++ b/docs/DevOpsREADME.md
@@ -1303,6 +1303,13 @@ gh secret list
 gcloud projects get-iam-policy ton-cat-lottery-dev-3 \
   --flatten="bindings[].members" \
   --filter="bindings.members:serviceAccount:gha-deploy@ton-cat-lottery-dev-3.iam.gserviceaccount.com"
+
+# 6. 修正常見權限問題：Service Account Token Creator
+# 錯誤：Permission 'iam.serviceAccounts.getAccessToken' denied
+# 解決：添加 serviceAccountTokenCreator 角色
+gcloud projects add-iam-policy-binding ton-cat-lottery-dev-3 \
+  --member="serviceAccount:gha-deploy@ton-cat-lottery-dev-3.iam.gserviceaccount.com" \
+  --role="roles/iam.serviceAccountTokenCreator"
 ```
 
 ##### 問題：映像建構與推送失敗

--- a/setup-gcp-oidc.sh
+++ b/setup-gcp-oidc.sh
@@ -12,7 +12,7 @@ set -e  # 遇到錯誤立即退出
 
 # 配置變數
 PROJECT_ID="ton-cat-lottery-dev-3"
-GITHUB_REPO="chaowei-liu/ton-cat-lottery"
+GITHUB_REPO="chaowei-dev/ton-cat-lottery"
 SERVICE_ACCOUNT_NAME="gha-deploy"
 WORKLOAD_IDENTITY_POOL_NAME="github-pool" 
 WORKLOAD_IDENTITY_PROVIDER_NAME="github-provider"

--- a/setup-gcp-oidc.sh
+++ b/setup-gcp-oidc.sh
@@ -105,6 +105,7 @@ REQUIRED_ROLES=(
     "roles/artifactregistry.writer"      # Artifact Registry 推送
     "roles/storage.admin"                # GCS bucket 管理 (Terraform state)
     "roles/serviceusage.serviceUsageConsumer"  # 服務使用權限
+    "roles/iam.serviceAccountTokenCreator"     # Service Account token 生成權限
 )
 
 for role in "${REQUIRED_ROLES[@]}"; do

--- a/test-cd.md
+++ b/test-cd.md
@@ -1,3 +1,4 @@
 # CD Test Tue  2 Sep 2025 01:18:38 CST
 # CD Test Fix Tue  2 Sep 2025 01:22:16 CST
 # OIDC Authentication Fix Verified Tue  2 Sep 2025 01:37:29 CST
+# PrincipalSet OIDC Fix Tue  2 Sep 2025 01:45:01 CST

--- a/test-cd.md
+++ b/test-cd.md
@@ -1,1 +1,2 @@
 # CD Test Tue  2 Sep 2025 01:18:38 CST
+# CD Test Fix Tue  2 Sep 2025 01:22:16 CST

--- a/test-cd.md
+++ b/test-cd.md
@@ -1,0 +1,1 @@
+# CD Test Tue  2 Sep 2025 01:18:38 CST

--- a/test-cd.md
+++ b/test-cd.md
@@ -1,2 +1,3 @@
 # CD Test Tue  2 Sep 2025 01:18:38 CST
 # CD Test Fix Tue  2 Sep 2025 01:22:16 CST
+# OIDC Authentication Fix Verified Tue  2 Sep 2025 01:37:29 CST


### PR DESCRIPTION
🔧 **完整的 OIDC 認證修正**

## 💡 **根本原因分析**
經過深入分析，發現問題在於 Workload Identity 綁定方式：
- ❌ 使用具體的 `subject` 綁定（不穩定）
- ✅ 改用 Google 推薦的 `principalSet` 綁定（穩定）

## 🎯 **修正內容**
1. **WIF Provider 修正**: 使用正確的 `github-provider-correct` (chaowei-dev 路徑)
2. **綁定方式升級**: `principalSet` 匹配整個 repository
3. **權限完整性**: 包含所有必要的 Service Account 權限
4. **文檔更新**: 完整的故障排除指南

## 🧪 **關鍵測試**
此 PR 到 dev 分支將測試：
- ✅ GitHub OIDC Token → Workload Identity Provider  
- ✅ Service Account Impersonation (principalSet 綁定)
- ✅ GKE 集群認證 (`gcloud container clusters get-credentials`)
- ✅ 完整的 Staging 部署流程

## 🎉 **預期結果**
- **無 `iam.serviceAccounts.getAccessToken` 錯誤**
- **CD pipeline 成功部署到 staging 環境**
- **外部可達性測試通過**: `dev.cat-lottery.chaowei-liu.com`